### PR TITLE
Renamed CI workflow so that it reflects in the build-status-badge

### DIFF
--- a/.github/workflows/node.js-ci.yml
+++ b/.github/workflows/node.js-ci.yml
@@ -1,7 +1,7 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: Build
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [website-url]: https://fabricjs.github.io/  "FabricJS website"
 
+![CI build status](https://github.com/fabricjs/fabricjs.github.io/workflows/Build/badge.svg)
+
 ![FabricJS logo](src/images/fabricjs-logo.png)
 
 # FabricJS website


### PR DESCRIPTION
Renamed the CI workflow from **Node.js CI** to **Build** so that it reflects in the build-status-badge.

This will change the badge title from ![Node.JS CI](https://github.com/fabricjs/fabricjs.github.io/workflows/Node.js%20CI/badge.svg) to ![Build](https://github.com/fabricjs/fabricjs.github.io/workflows/Build/badge.svg)