### PR TITLE
`package.json`: add `engines` and `packageManager` fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,10 @@
         "typedoc": "^0.26.2",
         "typedoc-plugin-markdown": "^4.0.0-next.54",
         "typedoc-plugin-no-inherit": "^1.4.0",
-        "typescript": "^5.4.2",
-        "yarn": "^1.22.22"
+        "typescript": "^5.4.2"
+      },
+      "engines": {
+        "node": "^18.17.1 || ^20.3.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -8954,19 +8956,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yarn": {
-      "version": "1.22.22",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.22.tgz",
-      "integrity": "sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==",
-      "hasInstallScript": true,
-      "bin": {
-        "yarn": "bin/yarn.js",
-        "yarnpkg": "bin/yarn.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
     "typedoc": "^0.26.2",
     "typedoc-plugin-markdown": "^4.0.0-next.54",
     "typedoc-plugin-no-inherit": "^1.4.0",
-    "typescript": "^5.4.2",
-    "yarn": "^1.22.22"
-  }
+    "typescript": "^5.4.2"
+  },
+  "engines": {
+    "node": "^18.17.1 || ^20.3.0"
+  },
+  "packageManager": "npm@10.8.1+sha512.0e9d42e92bd2318408ed81eaff2da5f78baf23ee7d12a6eed44a6e2901d0f29d7ab715d1b918ade601f72e769a824d9a5c322383f22bbbda5dd396e79de2a077"
 }


### PR DESCRIPTION
And remove unused `yarn` dependency.

Fixes #116.

`engines` line is partially copied from Astro:
https://github.com/withastro/astro/blob/main/package.json#L46-L48

... I removed reference to v21, as it's an odd-numbered release, and thus not going to become an LTS.