### PR TITLE
feat(resources): add resources section

### DIFF
--- a/src/components/Resources/Resources.astro
+++ b/src/components/Resources/Resources.astro
@@ -1,0 +1,21 @@
+---
+import './resources.css';
+
+const links = [
+    {
+        link: 'https://github.com/cs-open/react-fabric',
+        description: 'awesome  react + fabricjs library',
+        name: '@cs-open/react-fabric',
+    },
+  
+]
+
+---
+<section id="resources">
+  <h2>Resources</h2>
+    <ul>
+        {
+            links.map((link) => ()=> (<li><a href={link.link} target="_blank">{link.name}</a>: &nbsp;{link.description}</li>))
+        }
+    </ul>
+</section>

--- a/src/components/Resources/resources.css
+++ b/src/components/Resources/resources.css
@@ -1,0 +1,7 @@
+#resources {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-items: center;
+}
+

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import Companies from '../components/Companies/Companies.astro';
 import FeaturedBanner from '../components/FeaturedBanner/FeaturedBanner.astro';
 import Features from '../components/Features/Features.astro';
+import Resources from '../components/Resources/Resources.astro';
 import ContributorsList from '../components/ContributorsList/ContributorsList.astro';
 ---
 
@@ -11,6 +12,7 @@ import ContributorsList from '../components/ContributorsList/ContributorsList.as
 		<FeaturedBanner />
 		<Features />
 		<Companies />
+		<Resources />
 		<ContributorsList />
 	</main>
 </Layout>


### PR DESCRIPTION
add an resources section to docs 

first link is  [https://github.com/cs-open/react-fabric](https://github.com/cs-open/react-fabric), Bringing fabric to react


<img width="1400" alt="image" src="https://github.com/user-attachments/assets/759dd5e4-80ad-4b08-9c72-fec76096cb85" />
