### PR TITLE
Explain required attributes

### DIFF
--- a/src/content/demo/video-element/code.js
+++ b/src/content/demo/video-element/code.js
@@ -7,6 +7,7 @@ const video2source = document.createElement('source');
 
 const webcamEl = document.createElement('video');
 
+// FabricImage requires the width and height attributes to be set
 video1El.width = 480;
 video1El.height = 360;
 video1El.id = 'video1'


### PR DESCRIPTION
FabricImage will not be able to use the video element if the width and height attributes are not set.

This is not obvious, so adding a comment about it so people won't waste time figuring out why there code does not work.