### PR TITLE
Fix typo in docs

### DIFF
--- a/src/content/docs/docs/core-concepts.md
+++ b/src/content/docs/docs/core-concepts.md
@@ -11,7 +11,7 @@ This is an overview of the main building blocks of Fabric.js
 
 ## Canvas
 
-The main container for Fabric.js is the `StaticCavas` or the interactive version called simply `Canvas`.
+The main container for Fabric.js is the `StaticCanvas` or the interactive version called simply `Canvas`.
 This is a class that provides you the surface where you will draw and will also provide the tools to:
 
 - Handle selections and object interactions


### PR DESCRIPTION
Small typo in docs. 
<img width="1068" height="799" alt="Screenshot 2025-10-09 at 8 22 52 PM" src="https://github.com/user-attachments/assets/f52aef16-71a1-4a23-807a-f52d33b91fc6" />

This repo seems to be the live one even though it says here the website is in progress.

